### PR TITLE
micapp: fix app crash when extras is empty

### DIFF
--- a/app/src/main/java/com/facebook/micapp/MainActivity.java
+++ b/app/src/main/java/com/facebook/micapp/MainActivity.java
@@ -276,8 +276,8 @@ public class MainActivity extends AppCompatActivity {
         mAudioEffects = new AudioEffects();
         Bundle extras = this.getIntent().getExtras();
 
-        Log.d(TAG, "extras " + Utils.bundleToString(extras));
         if (extras != null) {
+            Log.d(TAG, "extras " + Utils.bundleToString(extras));
             setContentView(R.layout.activity_main_clean);
             mInfo = (TextView) findViewById(R.id.cleanInfo);
             if (extras.containsKey("inputid")) {


### PR DESCRIPTION
logging extras when value is null was causing an app crash,
executing log extras only if value is not null